### PR TITLE
Allow Partial Units for Page Margin

### DIFF
--- a/lib/webservices/pdf.js
+++ b/lib/webservices/pdf.js
@@ -16,7 +16,7 @@ if (process.platform !== 'darwin') {
 }
 var FORMATS = ['A3', 'A4', 'A5', 'Legal', 'Letter', 'Tabloid'];
 var ORIENTATIONS = ['portrait', 'landscape'];
-var marginRegExp = /^\d+(in|cm|mm)$/;
+var marginRegExp = /^((\d)|(\d\.\d))+(in|cm|mm)$/;
 var zoomRegExp = /^\d(\.\d{1,3})?$/;
 
 module.exports = function (app) {


### PR DESCRIPTION
Updated the RegExp to allow for more than strictly integer input (e.g.- 0.5in, 0.25cm, 2.5mm).

Tested using RegEx101:
- original RegExp: https://regex101.com/r/xC1wH2/1
- new RegExp: https://regex101.com/r/xC1wH2/2