### PR TITLE
Quote filename in Content-disposition

### DIFF
--- a/lib/webservices/pdf.js
+++ b/lib/webservices/pdf.js
@@ -94,7 +94,7 @@ module.exports = function (app) {
 					}
 					res.header('content-type', 'application/pdf');
 					if(req.query.download==='true'){
-						res.setHeader('Content-disposition', 'attachment; filename=' + filename + '.pdf');
+						res.setHeader('Content-disposition', 'attachment; filename="' + filename + '.pdf"');
 					}
 					if(req.query.downloadToken){
 						res.setHeader('Set-Cookie', 'downloadToken=' + req.query.downloadToken);


### PR DESCRIPTION
The filename should be quoted in the Content-disposition: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

If there are spaces in the filename, some browsers (e.g. Chrome) handle it ok, while others (e.g. Firefox) truncate the filename at the first space.

This fixes issue #55